### PR TITLE
Fix hydration mismatch in TerminalOne (React error #418)

### DIFF
--- a/src/components/ui/TerminalOne.tsx
+++ b/src/components/ui/TerminalOne.tsx
@@ -23,8 +23,16 @@ export default function TerminalOne() {
   const [typedOutput, setTypedOutput] = useState<string>("");
   const [isTyping, setIsTyping] = useState(false);
   const [expandedDirs, setExpandedDirs] = useState<Record<string, boolean>>({ "tools": true, "web": true });
-  
+  const [isMobile, setIsMobile] = useState(false);
+
   const debounceTimer = useRef<NodeJS.Timeout | null>(null);
+
+  useEffect(() => {
+    const checkIsMobile = () => setIsMobile(window.innerWidth < 768);
+    checkIsMobile();
+    window.addEventListener("resize", checkIsMobile);
+    return () => window.removeEventListener("resize", checkIsMobile);
+  }, []);
 
   const miniProjects = projectsData.filter((p) => p.type === "mini");
   
@@ -142,7 +150,7 @@ export default function TerminalOne() {
                 </button>
                 
                 <AnimatePresence initial={false}>
-                  {(expandedDirs[dir] || typeof window !== 'undefined' && window.innerWidth < 768) && (
+                  {(expandedDirs[dir] || isMobile) && (
                     <motion.div 
                       initial={{ height: 0, opacity: 0 }}
                       animate={{ height: "auto", opacity: 1 }}


### PR DESCRIPTION
## Summary
- `TerminalOne.tsx` read `window.innerWidth` directly in the render path to decide whether a project directory should show expanded on mobile. The server always sees `window` as undefined and renders `false`; the client's first render already has the real viewport width, so on screens under 768px it rendered `true` instead — a server/client mismatch React reports as error #418.
- Moved the viewport check into `isMobile` state, set from `useEffect` after mount (with a resize listener), so the initial client render matches the server exactly and the mobile-open behavior applies after hydration completes.

## Test plan
- [x] `next build` succeeds
- [x] Confirmed no other `typeof window` render-time reads remain in `src`

🤖 Generated with [Claude Code](https://claude.com/claude-code)