### PR TITLE
Fix favicon theme switching: use JS matchMedia (Chromium ignores link media attr)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Turret_Road, Numans } from "next/font/google";
+import Script from "next/script";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import GoToTopButton from "@/components/ui/GoToTopButton";
@@ -67,8 +68,7 @@ export const metadata: Metadata = {
   },
   icons: {
     icon: [
-      { url: "/favicon-light.svg", type: "image/svg+xml", media: "(prefers-color-scheme: light)" },
-      { url: "/favicon-dark.svg", type: "image/svg+xml", media: "(prefers-color-scheme: dark)" },
+      { url: "/favicon-light.svg", type: "image/svg+xml" },
       { url: "/favicon.ico", sizes: "any" },
     ],
     apple: [{ url: "/apple-icon" }],
@@ -97,6 +97,24 @@ export default function RootLayout({
       <body
         className={`${numans.variable} ${turretRoad.variable} font-sans antialiased bg-white text-black min-h-screen flex flex-col`}
       >
+        <Script id="theme-favicon" strategy="beforeInteractive">
+          {`
+            (function () {
+              function setFavicon() {
+                var isDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+                var href = isDark ? "/favicon-dark.svg" : "/favicon-light.svg";
+                var link = document.querySelector('link[rel="icon"][type="image/svg+xml"]');
+                if (link && link.getAttribute("href") !== href) {
+                  link.setAttribute("href", href);
+                }
+              }
+              setFavicon();
+              window
+                .matchMedia("(prefers-color-scheme: dark)")
+                .addEventListener("change", setFavicon);
+            })();
+          `}
+        </Script>
         {children}
         <Analytics />
         <SpeedInsights />


### PR DESCRIPTION
## Summary
- PR #37 used the `media` attribute on separate `<link rel="icon">` tags, which is the documented/standard technique -- but Chromium (Chrome/Edge) has a long-standing bug where it doesn't honor `media` for favicon selection. Confirmed on a completely fresh Edge profile (first-ever visit, no cache possible) with Windows explicitly set to dark mode: the favicon still rendered the light/black variant.
- Replaced with a `beforeInteractive` inline script that checks `matchMedia("(prefers-color-scheme: dark)")` and sets the favicon `<link>`'s `href` directly, plus a `change` listener so it keeps switching live if the OS theme changes without a page reload.
- Verified with Playwright (Chromium) emulating both color schemes -- the link's `href` correctly resolves to `favicon-dark.svg` / `favicon-light.svg`.

## Test plan
- [x] `next build` succeeds
- [x] Playwright verification: dark color-scheme context -> `favicon-dark.svg`, light -> `favicon-light.svg`
- [ ] Visual confirmation on production in Edge/Chrome with OS dark mode on

🤖 Generated with [Claude Code](https://claude.com/claude-code)