### PR TITLE
Fix Total Contributions stat undercounting on GitHub timeline

### DIFF
--- a/src/components/sections/GitHubTimeline.tsx
+++ b/src/components/sections/GitHubTimeline.tsx
@@ -11,7 +11,6 @@ interface ContributionDay {
 
 interface GitHubTimelineProps {
   contributions: ContributionDay[];
-  totalCommits?: number;
   totalStars?: number;
 }
 
@@ -171,7 +170,6 @@ function ContributionSquare({ day }: { day?: ContributionDay }) {
  */
 export function GitHubTimeline({
   contributions,
-  totalCommits: passedTotalCommits,
   totalStars: passedTotalStars,
 }: GitHubTimelineProps) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -186,7 +184,7 @@ export function GitHubTimeline({
   const weeks = organizeIntoWeeks(nonFutureContributions);
 
   // Calculate stats
-  const totalCommits = passedTotalCommits ?? contributions.reduce(
+  const totalContributions = contributions.reduce(
     (sum, day) => sum + day.contributionCount,
     0
   );
@@ -291,7 +289,7 @@ export function GitHubTimeline({
             Total Contributions
           </p>
           <p className="text-2xl font-bold text-accent">
-            {totalCommits.toLocaleString()}
+            {totalContributions.toLocaleString()}
           </p>
         </div>
         <div className="space-y-1">

--- a/src/components/sections/GitHubTimelineServer.tsx
+++ b/src/components/sections/GitHubTimelineServer.tsx
@@ -68,7 +68,6 @@ async function GitHubTimelineContent({
   return (
     <GitHubTimeline
       contributions={contributions}
-      totalCommits={stats?.totalCommits}
       totalStars={stats?.totalStars}
     />
   );

--- a/src/lib/github-contributions.ts
+++ b/src/lib/github-contributions.ts
@@ -155,19 +155,14 @@ export async function fetchGitHubContributions(
 }
 
 /**
- * Fetches user stats including total contributions and starred repositories
- * Total contributions calculated from commit contributions
+ * Fetches total stars across the user's non-fork repositories
  */
 export async function fetchGitHubStats(username: string): Promise<{
-  totalCommits: number;
   totalStars: number;
 }> {
   const query = `
     query {
       user(login: "${username}") {
-        contributionsCollection {
-          totalCommitContributions
-        }
         repositories(first: 100, isFork: false) {
           nodes {
             stargazerCount
@@ -197,7 +192,6 @@ export async function fetchGitHubStats(username: string): Promise<{
   const data = (await response.json()) as {
     data?: {
       user: {
-        contributionsCollection: { totalCommitContributions: number };
         repositories: { nodes: Array<{ stargazerCount: number }> };
       };
     };
@@ -213,13 +207,12 @@ export async function fetchGitHubStats(username: string): Promise<{
     throw new Error("User not found");
   }
 
-  const totalCommits = user.contributionsCollection.totalCommitContributions;
   const totalStars = user.repositories.nodes.reduce(
     (sum, repo) => sum + repo.stargazerCount,
     0
   );
 
-  return { totalCommits, totalStars };
+  return { totalStars };
 }
 
 /**


### PR DESCRIPTION
## Summary
- The "Total Contributions" stat showed 1,635 while the calendar directly below it correctly totaled 2,632 for the same 2024-2026 range.
- Root cause: the stat was fed by `fetchGitHubStats().totalCommits`, which queried `contributionsCollection.totalCommitContributions` with no date range (defaulting to a rolling last-365-days window) and only counted commits, excluding issues/PRs/reviews that the calendar itself already includes.
- Fix: removed that separate, inconsistent query. The stat now always derives from summing the per-day contribution data that's already fetched for the calendar, so it's mathematically guaranteed to match what's rendered. `fetchGitHubStats` now only fetches star counts, its one remaining use.

## Test plan
- [x] `next build` succeeds
- [x] Verified locally: "Total Contributions" renders 2,632, matching the sum of all rendered day tooltips exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)